### PR TITLE
Add status field to Release and colourize the calender events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /bin
 /build
+/target
+pom.xml
+.mvn/
+mvnw*
 .gradle/
 .settings/
 .project

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ mvnw*
 .settings/
 .project
 .classpath
+.factorypath

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.4.0.RC1")
+		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.4.0.RELEASE")
 	}
 }
 

--- a/src/main/java/io/spring/calendar/github/GitHubProjectReleasesSupplier.java
+++ b/src/main/java/io/spring/calendar/github/GitHubProjectReleasesSupplier.java
@@ -26,9 +26,11 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.spring.calendar.github.Milestone.State;
 import io.spring.calendar.release.Project;
 import io.spring.calendar.release.ProjectReleases;
 import io.spring.calendar.release.Release;
+import io.spring.calendar.release.Release.Status;
 
 /**
  * A {@link Supplier} of {@link ProjectReleases} for projects managed on GitHub.
@@ -103,7 +105,11 @@ class GitHubProjectReleasesSupplier implements Supplier<List<ProjectReleases>> {
 				new Project(repository.getDisplayName(), repository.getHtmlUrl()),
 				milestone.getTitle(),
 				milestone.getDueOn().withZoneSameInstant(ZoneId.of("Europe/London"))
-						.format(DateTimeFormatter.ISO_LOCAL_DATE));
+						.format(DateTimeFormatter.ISO_LOCAL_DATE), getStatus(milestone));
+	}
+
+	private Status getStatus(Milestone milestone) {
+		return milestone.getState() == State.open ? Status.OPEN : Status.CLOSED;
 	}
 
 }

--- a/src/main/java/io/spring/calendar/github/GitHubTemplate.java
+++ b/src/main/java/io/spring/calendar/github/GitHubTemplate.java
@@ -58,7 +58,7 @@ class GitHubTemplate implements GitHubOperations {
 	 */
 	GitHubTemplate(String username, String password, LinkParser linkParser,
 			RestTemplateBuilder restTemplateBuilder) {
-		if (StringUtils.hasText(username) && StringUtils.hasText(password)) {
+		if (StringUtils.hasText(username) || StringUtils.hasText(password)) {
 			restTemplateBuilder = restTemplateBuilder.basicAuthorization(username,
 					password);
 		}

--- a/src/main/java/io/spring/calendar/github/Milestone.java
+++ b/src/main/java/io/spring/calendar/github/Milestone.java
@@ -29,15 +29,27 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 class Milestone {
 
+	/**
+	 * State of the milestone according to github.
+	 *
+	 */
+	static enum State {
+		open, closed
+	};
+
 	private final String title;
 
 	private final ZonedDateTime dueOn;
 
+	private final State state;
+
 	@JsonCreator
 	Milestone(@JsonProperty("title") String title,
-			@JsonProperty("due_on") ZonedDateTime dueOn) {
+			@JsonProperty("due_on") ZonedDateTime dueOn,
+			@JsonProperty("state") State state) {
 		this.title = title;
 		this.dueOn = dueOn == null ? null : dueOn.withZoneSameInstant(ZoneId.of("UTC"));
+		this.state = state;
 	}
 
 	String getTitle() {
@@ -46,6 +58,10 @@ class Milestone {
 
 	ZonedDateTime getDueOn() {
 		return this.dueOn;
+	}
+
+	public State getState() {
+		return this.state;
 	}
 
 }

--- a/src/main/java/io/spring/calendar/ical/ICalProjectReleasesSupplier.java
+++ b/src/main/java/io/spring/calendar/ical/ICalProjectReleasesSupplier.java
@@ -34,6 +34,7 @@ import biweekly.component.VEvent;
 import io.spring.calendar.release.Project;
 import io.spring.calendar.release.ProjectReleases;
 import io.spring.calendar.release.Release;
+import io.spring.calendar.release.Release.Status;
 
 /**
  * A {@link Supplier} of {@link ProjectReleases} for {@link ICalProject ICalProjects}.
@@ -90,7 +91,11 @@ class ICalProjectReleasesSupplier implements Supplier<List<ProjectReleases>> {
 		}
 		return new Release(new Project(project.getName()), name,
 				new SimpleDateFormat("yyyy-MM-dd")
-						.format(event.getDateStart().getValue()));
+						.format(event.getDateStart().getValue()), getStatus(event));
+	}
+
+	private Status getStatus(VEvent event) {
+		return event.getStatus() == biweekly.property.Status.completed() ? Status.CLOSED : Status.OPEN;
 	}
 
 	private static List<ICalProject> createProjects() {

--- a/src/main/java/io/spring/calendar/jira/JiraProjectReleasesSupplier.java
+++ b/src/main/java/io/spring/calendar/jira/JiraProjectReleasesSupplier.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Component;
 import io.spring.calendar.release.Project;
 import io.spring.calendar.release.ProjectReleases;
 import io.spring.calendar.release.Release;
+import io.spring.calendar.release.Release.Status;
 
 /**
  * A {@link Supplier} of {@link ProjectReleases} for projects managed in JIRA.
@@ -70,12 +71,16 @@ class JiraProjectReleasesSupplier implements Supplier<List<ProjectReleases>> {
 	private Release createRelease(JiraProject jiraProject, JiraVersion version) {
 		try {
 			Project project = new Project(jiraProject.getName());
-			return new Release(project, version.getName(), version.getReleaseDate());
+			return new Release(project, version.getName(), version.getReleaseDate(), getStatus(version));
 		}
 		catch (Exception ex) {
 			throw new IllegalStateException(
 					"Failed to parse " + version.getReleaseDate());
 		}
+	}
+
+	private Status getStatus(JiraVersion version) {
+		return version.isReleased() ? Status.CLOSED : Status.OPEN;
 	}
 
 }

--- a/src/main/java/io/spring/calendar/jira/JiraVersion.java
+++ b/src/main/java/io/spring/calendar/jira/JiraVersion.java
@@ -30,11 +30,14 @@ class JiraVersion {
 
 	private final String releaseDate;
 
+	private final boolean released;
+
 	@JsonCreator
 	JiraVersion(@JsonProperty("name") String name,
-			@JsonProperty("releaseDate") String releaseDate) {
+			@JsonProperty("releaseDate") String releaseDate, @JsonProperty("released") boolean released) {
 		this.name = name;
 		this.releaseDate = releaseDate;
+		this.released = released;
 	}
 
 	String getName() {
@@ -43,6 +46,10 @@ class JiraVersion {
 
 	String getReleaseDate() {
 		return this.releaseDate;
+	}
+
+	public boolean isReleased() {
+		return this.released;
 	}
 
 }

--- a/src/main/java/io/spring/calendar/release/Release.java
+++ b/src/main/java/io/spring/calendar/release/Release.java
@@ -23,11 +23,32 @@ package io.spring.calendar.release;
  */
 public class Release {
 
+	/**
+	 * Status of the release, if known.
+	 *
+	 */
+	public static enum Status {
+		/**
+		 * The release is open (not yet closed).
+		 */
+		OPEN,
+		/**
+		 * The release is closed (completed).
+		 */
+		CLOSED,
+		/**
+		 * The release status is not known.
+		 */
+		UNKNOWN
+	};
+
 	private final Project project;
 
 	private final String name;
 
 	private final String date;
+
+	private final Status status;
 
 	/**
 	 * Creates a new {@code Release}.
@@ -35,11 +56,13 @@ public class Release {
 	 * @param project the project
 	 * @param name the name of the release
 	 * @param date the date of the release (yyyy-mm-dd)
+	 * @param status the status of the release
 	 */
-	public Release(Project project, String name, String date) {
+	public Release(Project project, String name, String date, Status status) {
 		this.project = project;
 		this.name = name;
 		this.date = date;
+		this.status = status;
 	}
 
 	Project getProject() {
@@ -54,4 +77,7 @@ public class Release {
 		return this.date;
 	}
 
+	Status getStatus() {
+		return this.status;
+	}
 }

--- a/src/main/java/io/spring/calendar/release/ReleaseEventsController.java
+++ b/src/main/java/io/spring/calendar/release/ReleaseEventsController.java
@@ -16,6 +16,9 @@
 
 package io.spring.calendar.release;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +28,8 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import io.spring.calendar.release.Release.Status;
 
 /**
  * Controller for exposing {@link Release Releases} as Full Calendar events.
@@ -49,6 +54,21 @@ class ReleaseEventsController {
 			event.put("allDay", true);
 			event.put("start", release.getDate());
 			event.put("url", release.getProject().getUrl());
+			if (release.getStatus() == Status.CLOSED) {
+				event.put("backgroundColor", "#6db33f");
+			}
+			else if (release.getStatus() == Status.OPEN) {
+				try {
+					Date date = new SimpleDateFormat("yyyy-MM-dd")
+							.parse(release.getDate());
+					if (date.before(new Date())) {
+						event.put("backgroundColor", "#d14");
+					}
+				}
+				catch (ParseException ex) {
+				}
+
+			}
 			return event;
 		}).collect(Collectors.toList());
 	}

--- a/src/main/java/io/spring/calendar/release/ReleaseICalController.java
+++ b/src/main/java/io/spring/calendar/release/ReleaseICalController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 import biweekly.Biweekly;
 import biweekly.ICalendar;
 import biweekly.component.VEvent;
+import io.spring.calendar.release.Release.Status;
 
 /**
  * Controller for exposing {@link Release Releases} as an iCalendar-format download.
@@ -61,6 +62,9 @@ class ReleaseICalController {
 			Date date = new SimpleDateFormat("yyyy-MM-dd").parse(release.getDate());
 			event.setDateStart(date, false);
 			event.setDateEnd(date, false);
+			if (release.getStatus() == Status.CLOSED) {
+				event.setStatus(biweekly.property.Status.completed());
+			}
 		}
 		catch (ParseException ex) {
 			throw new RuntimeException(ex);

--- a/src/main/java/io/spring/calendar/release/ReleaseUpdater.java
+++ b/src/main/java/io/spring/calendar/release/ReleaseUpdater.java
@@ -81,7 +81,7 @@ class ReleaseUpdater {
 		Project project = new Project(
 				this.projectNameAliaser.apply(release.getProject().getName()),
 				release.getProject().getUrl());
-		return new Release(project, release.getName(), release.getDate());
+		return new Release(project, release.getName(), release.getDate(), release.getStatus());
 	}
 
 	private void updateReleases(List<Release> releases) {

--- a/src/test/java/io/spring/calendar/github/GitHubTemplateTests.java
+++ b/src/test/java/io/spring/calendar/github/GitHubTemplateTests.java
@@ -94,6 +94,7 @@ public class GitHubTemplateTests {
 		Page<Milestone> page = this.gitHub.getMilestones(this.repository, null);
 		assertThat(page.getContent()).hasSize(68);
 		this.server.verify();
+		assertThat(page.getContent().get(67).getState()).isEqualTo(Milestone.State.open);
 	}
 
 	@Test

--- a/src/test/java/io/spring/calendar/jira/JiraTemplateTests.java
+++ b/src/test/java/io/spring/calendar/jira/JiraTemplateTests.java
@@ -75,6 +75,7 @@ public class JiraTemplateTests {
 				URI.create("https://jira.spring.io/rest/api/2/project/SPR")));
 		assertThat(versions).hasSize(161);
 		JiraVersion version = versions.get(40);
+		assertThat(version.isReleased()).isEqualTo(true);
 		assertThat(version.getName()).isEqualTo("2.0.4");
 		assertThat(version.getReleaseDate()).isEqualTo("2007-04-09");
 	}


### PR DESCRIPTION
JIRA and Github both provide status information in their API responses so
it is possible to unify that into a single model and render events
differently accroding to their status.

This change adds the status field as an enum in Release, and then sets the
background colour of the rendered event, green for released and red for open
but past due.
